### PR TITLE
Add leaderboard overlay and button

### DIFF
--- a/game.js
+++ b/game.js
@@ -63,14 +63,14 @@ export function showLeaderboard() {
   updateLeaderboard();
   const overlay = document.getElementById('leaderboardOverlay');
   if (overlay) {
-    overlay.classList.remove('hidden');
+    overlay.classList.add('show');
   }
 }
 
 export function hideLeaderboard() {
   const overlay = document.getElementById('leaderboardOverlay');
   if (overlay) {
-    overlay.classList.add('hidden');
+    overlay.classList.remove('show');
   }
 }
 

--- a/hud.js
+++ b/hud.js
@@ -14,8 +14,10 @@ function initHUD() {
   leaderboardList = document.getElementById('leaderboardList');
   const leaderboardButton = document.getElementById('leaderboardButton');
   const closeLeaderboard = document.getElementById('closeLeaderboard');
-  if (leaderboardButton) leaderboardButton.addEventListener('click', showLeaderboard);
-  if (closeLeaderboard) closeLeaderboard.addEventListener('click', hideLeaderboard);
+  if (leaderboardButton)
+    leaderboardButton.addEventListener('click', showLeaderboard);
+  if (closeLeaderboard)
+    closeLeaderboard.addEventListener('click', hideLeaderboard);
   updateLeaderboard();
 }
 
@@ -48,11 +50,11 @@ function updateLeaderboard() {
 
 function showLeaderboard() {
   updateLeaderboard();
-  if (leaderboardOverlay) leaderboardOverlay.classList.remove('hidden');
+  if (leaderboardOverlay) leaderboardOverlay.classList.add('show');
 }
 
 function hideLeaderboard() {
-  if (leaderboardOverlay) leaderboardOverlay.classList.add('hidden');
+  if (leaderboardOverlay) leaderboardOverlay.classList.remove('show');
 }
 
 export { updateHUD, saveScore, showLeaderboard, hideLeaderboard };

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-
 <head>
   <title>Space Invaders</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -14,6 +13,7 @@
     <div>High Score: <span id="highScore">0</span></div>
     <div>Lives: <span id="lives">3</span></div>
     <div>Level: <span id="level">1</span></div>
+    <button id="leaderboardButton">Leaderboard</button>
   </div>
 
   <canvas id="bgCanvas" width="800" height="600"></canvas>
@@ -40,6 +40,14 @@
     <p>Press P to resume</p>
   </div>
 
+  <div id="leaderboardOverlay" class="overlay">
+    <div class="leaderboard-content">
+      <h2>Leaderboard</h2>
+      <ol id="leaderboardList"></ol>
+      <button id="closeLeaderboard">Close</button>
+    </div>
+  </div>
+
   <div id="mobileControls">
     <button id="leftButton">Left</button>
     <button id="shootButton">Shoot</button>
@@ -52,102 +60,6 @@
     const game = new Game();
     game.start();
   </script>
-=======
-  <head>
-    <title>Space Invaders</title>
-
-    <link rel="stylesheet" type="text/css" href="styles.css" />
-  </head>
-  <body>
-    <canvas id="bgCanvas" width="800" height="600"></canvas>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
-=======
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-    <link rel="stylesheet" type="text/css" href="styles.css">
-</head>
-<body>
-    <div id="hud">
-        <div>Score: <span id="score">0</span></div>
-        <div>High Score: <span id="highScore">0</span></div>
-        <div>Lives: <span id="lives">3</span></div>
-        <div>Level: <span id="level">1</span></div>
-    </div>
-
-=======
-=======
-=======
-  <link rel="stylesheet" type="text/css" href="styles.css">
-</head>
-<body>
-    <canvas id="bgCanvas" width="800" height="600"></canvas>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
-=======
-    <canvas id="gameCanvas"></canvas>
-=======
-
-    <div id="hud">
-      <div>Score: <span id="score">0</span></div>
-      <div>High Score: <span id="highScore">0</span></div>
-      <div>Lives: <span id="lives">3</span></div>
-      <div>Level: <span id="level">1</span></div>
-    </div>
-=======
-=======
-
-    <canvas id="bgCanvas" width="800" height="600"></canvas>
-    <canvas id="gameCanvas" width="800" height="600"></canvas>
-
-    <div id="startOverlay" class="overlay show">
-      <button id="startButton">Start Game</button>
-    </div>
-
-    <div id="gameOverOverlay" class="overlay">
-      <div>Game Over</div>
-      <button id="restartButton">Restart</button>
-    </div>
-
-    <div id="pauseOverlay" class="overlay"><div>Paused</div></div>
-
-    <script type="module">
-      import Game from './game.js';
-      const game = new Game();
-      // Start is triggered by Start button
-    </script>
-  </body>
-=======
-=======
-    <button id="leaderboardButton">Leaderboard</button>
-    <div id="leaderboardOverlay" class="overlay hidden">
-        <div class="leaderboard-content">
-            <h2>Leaderboard</h2>
-            <ol id="leaderboardList"></ol>
-            <button id="closeLeaderboard">Close</button>
-        </div>
-    </div>
-
-=======
-
-    <div id="mobileControls">
-        <button id="leftButton">Left</button>
-        <button id="shootButton">Shoot</button>
-        <button id="rightButton">Right</button>
-    </div>
-
-    <div id="pauseOverlay">
-        <h1>Paused</h1>
-        <p>Press P to resume</p>
-    </div>
-
-
-    <script src="starfield.js"></script>
-    <script type="module">
-        import Game from './game.js';
-        const game = new Game();
-        game.start();
-    </script>
-
 </body>
 </html>
 

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,13 @@ canvas {
     background-color: #00cc00;
 }
 
+.leaderboard-content {
+    background-color: rgba(0, 0, 0, 0.8);
+    padding: 20px;
+    border-radius: 5px;
+    text-align: center;
+}
+
 @keyframes slide-down {
     from {
         transform: translateY(-100%);


### PR DESCRIPTION
## Summary
- Add HUD button to open a new leaderboard overlay
- Style leaderboard overlay for consistent look
- Wire leaderboard controls to show and hide the overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a369481b708328a3173b60308741a8