### PR TITLE
Consolidate canvas and overlay styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,8 @@ canvas {
 
 #gameCanvas {
     z-index: 1;
+    width: 100vw;
+    height: 100vh;
 }
 
 /* Overlay */
@@ -51,6 +53,14 @@ canvas {
 .overlay.show {
     opacity: 1;
     visibility: visible;
+}
+
+#gameOverOverlay {
+    display: none;
+}
+
+#gameOverOverlay.show {
+    display: flex;
 }
 
 .overlay.slide {


### PR DESCRIPTION
## Summary
- merge conflicting `#gameCanvas` rules into one responsive block
- ensure `#gameOverOverlay` hides by default and shows correctly

## Testing
- `curl -s -F "file=@styles.css" "https://jigsaw.w3.org/css-validator/validator?output=text" > css-validation.log && grep -n "Congratulations" css-validation.log`

------
https://chatgpt.com/codex/tasks/task_e_68a3696f7d58832895262ef7ecfb3534