### PR TITLE
Hook up mobile controls and overlay buttons to game

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-=======
-  <link rel="stylesheet" type="text/css" href="styles.css" />
 </head>
 <body>
   <div id="gameContainer">
@@ -58,22 +56,13 @@
     </div>
   </div>
 
-  <script src="starfield.js"></script>
-=======
   <script type="module">
     import Game from './game.js';
     import { initGameUI } from './ui.js';
 
     const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
+    initGameUI(game);
   </script>
-=======
-=======
-    const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-  </script>
-=======
-  <script type="module" src="./game.js"></script>
 </body>
 </html>
 

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,5 @@
 import { initHUD } from './hud.js';
+import { hideOverlay } from './game.js';
 
 function initGameUI(game) {
   initHUD();
@@ -7,11 +8,60 @@ function initGameUI(game) {
   const restartButton = document.getElementById('restartButton');
   const playAgainButton = document.getElementById('playAgainButton');
 
-=======
-  if (startButton) startButton.addEventListener('click', () => game.start());
-  if (restartButton) restartButton.addEventListener('click', () => game.reset());
-  if (playAgainButton)
-    playAgainButton.addEventListener('click', () => game.reset());
+  const leftButton = document.getElementById('leftButton');
+  const rightButton = document.getElementById('rightButton');
+  const shootButton = document.getElementById('shootButton');
+
+  const bindMove = (btn, start, stop) => {
+    btn.addEventListener('pointerdown', start);
+    btn.addEventListener('pointerup', stop);
+    btn.addEventListener('pointerleave', stop);
+  };
+
+  if (leftButton)
+    bindMove(
+      leftButton,
+      () => game.player.moveLeft(),
+      () => game.player.stopLeft()
+    );
+
+  if (rightButton)
+    bindMove(
+      rightButton,
+      () => game.player.moveRight(),
+      () => game.player.stopRight()
+    );
+
+  if (shootButton) {
+    shootButton.addEventListener('click', () => {
+      if (!game.bullet.isFired) {
+        game.bullet.fire(
+          game.player.x + game.player.width / 2,
+          game.player.y
+        );
+      }
+    });
+  }
+
+  if (startButton) {
+    startButton.addEventListener('click', () => {
+      game.start();
+      hideOverlay('startOverlay');
+    });
+  }
+  if (restartButton) {
+    restartButton.addEventListener('click', () => {
+      game.reset();
+      hideOverlay('gameOverOverlay');
+    });
+  }
+  if (playAgainButton) {
+    playAgainButton.addEventListener('click', () => {
+      game.reset();
+      hideOverlay('winOverlay');
+    });
+  }
 }
 
 export { initGameUI };
+


### PR DESCRIPTION
## Summary
- Add UI handlers for mobile control buttons to move and fire
- Wire start/restart/play again buttons to game start/reset and overlay hiding
- Import and initialize game UI in index.html before gameplay starts

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4471fda748328857cc9ac60056a9e