### PR TITLE
refactor: centralize UI initialization

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,27 +8,6 @@ import {
   showLeaderboard,
   hideLeaderboard,
 } from './hud.js';
-=======
-  hideLeaderboard
-} from './hud.js';
-
-// Game configuration constants
-const PLAYER_WIDTH = 40;
-const PLAYER_HEIGHT = 30;
-const PLAYER_SPEED = 5;
-
-const BULLET_WIDTH = 5;
-const BULLET_HEIGHT = 15;
-const BULLET_SPEED = 7;
-
-const ENEMY_WIDTH = 30;
-const ENEMY_HEIGHT = 30;
-const ENEMY_ROWS = 5;
-const ENEMY_COLUMNS = 10;
-const ENEMY_PADDING = 10;
-const ENEMY_OFFSET_TOP = 50;
-const ENEMY_OFFSET_LEFT = 50;
-const ENEMY_BASE_SPEED = 1;
 
 export function showOverlay(id) {
   const el = document.getElementById(id);
@@ -46,65 +25,9 @@ export default class Game {
     this.context = this.canvas.getContext('2d');
     const bgCanvas = document.getElementById('bgCanvas');
     this.starfield = bgCanvas ? new Starfield(bgCanvas) : null;
-=======
-=======
-    this.canvas = document.getElementById('gameCanvas');
-    this.context = this.canvas.getContext('2d');
-    const bgCanvas = document.getElementById('bgCanvas');
-    if (bgCanvas) this.starfield = new Starfield(bgCanvas);
-
-    // Game constants
-    this.gameWidth = this.canvas.width;
-    this.gameHeight = this.canvas.height;
-    this.playerWidth = 40;
-    this.playerHeight = 30;
-    this.playerSpeed = 5;
-    this.bulletWidth = 5;
-    this.bulletHeight = 15;
-    this.bulletSpeed = 7;
-    this.enemyWidth = 30;
-    this.enemyHeight = 30;
-=======
-=======
-=======
-    // Canvas and starfield
-    this.canvas = document.getElementById('gameCanvas');
-    this.ctx = this.canvas.getContext('2d');
-    const bgCanvas = document.getElementById('bgCanvas');
-    this.starfield = new Starfield(bgCanvas);
 
     this.gameWidth = this.canvas.width;
     this.gameHeight = this.canvas.height;
-=======
-
-    this.gameWidth = this.canvas.width;
-    this.gameHeight = this.canvas.height;
-
-    this.player = new Player(
-      this.gameWidth / 2 - PLAYER_WIDTH / 2,
-      this.gameHeight - PLAYER_HEIGHT - 10,
-      PLAYER_WIDTH,
-      PLAYER_HEIGHT,
-      PLAYER_SPEED,
-      '#00ff00'
-    );
-
-    this.bullet = new Bullet(
-      BULLET_WIDTH,
-      BULLET_HEIGHT,
-      BULLET_SPEED,
-      '#ff0000'
-    );
-
-    this.enemies = [];
-    this.enemySpeed = ENEMY_BASE_SPEED;
-=======
-    // Colors
-    const styles = getComputedStyle(document.documentElement);
-    this.primaryColor =
-      styles.getPropertyValue('--color-primary').trim() || '#00ff00';
-    this.accentColor =
-      styles.getPropertyValue('--color-accent').trim() || '#ff0000';
 
     this.player = new Player(
       this.gameWidth / 2 - 20,
@@ -121,674 +44,135 @@ export default class Game {
     this.enemyPadding = 10;
     this.enemyOffsetTop = 50;
     this.enemyOffsetLeft = 50;
-=======
     this.enemies = [];
     this.enemyDirection = 1;
     this.enemySpeed = 1;
-    this.spawnEnemies();
-=======
-    this.bullet = new Bullet(5, 15, 7, this.accentColor);
-
-    // Enemy configuration
-    this.enemyCols = 10;
-    this.enemyRows = 5;
-    this.enemyWidth = 30;
-    this.enemyHeight = 30;
-    this.enemyPadding = 10;
-    this.enemyOffsetTop = 50;
-    this.enemyOffsetLeft = 50;
-
-    // Entities
-    this.player = new Player(
-      this.gameWidth / 2 - this.playerWidth / 2,
-      this.gameHeight - this.playerHeight - 10,
-      this.playerWidth,
-      this.playerHeight,
-      this.playerSpeed,
-      '#00ff00'
-    );
-    this.bullet = new Bullet(
-      this.bulletWidth,
-      this.bulletHeight,
-      this.bulletSpeed,
-      '#ff0000'
-    );
-
-    this.enemies = [];
-    this.spawnEnemies();
-=======
-=======
-    this.enemySpeed = 1;
-    this.enemyDirection = 1;
-    this.enemies = [];
-
-    // Particles
-    this.particles = [];
 
     this.score = 0;
-    this.highScore = parseInt(localStorage.getItem('highScore'), 10) || 0;
+    this.highScore = parseInt(localStorage.getItem('highScore') || '0', 10);
     this.lives = 3;
     this.level = 1;
 
     this.gameLoop = this.gameLoop.bind(this);
-=======
-    this.isPaused = false;
-    this.gameOver = false;
-    this.gameWon = false;
-    this.isPaused = false;
-    this.pausePressed = false;
-
-    // Overlays
-    this.startOverlay = document.getElementById('startOverlay');
-    this.gameOverOverlay = document.getElementById('gameOverOverlay');
-    this.pauseOverlay = document.getElementById('pauseOverlay');
-
-    // Bind handlers
-=======
-    this.paused = false;
-    this.lastTime = 0;
-
-    // Input
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleKeyUp = this.handleKeyUp.bind(this);
-    window.addEventListener('keydown', this.handleKeyDown);
-    window.addEventListener('keyup', this.handleKeyUp);
 
-  start() {
-    hideOverlay('startOverlay');
-    hideOverlay('gameOverOverlay');
-    hideOverlay('pauseOverlay');
-    hideLeaderboard();
     this.resetState();
-    document.addEventListener('keydown', this.handleKeyDown);
-    document.addEventListener('keyup', this.handleKeyUp);
-    this.gameLoop();
   }
 
-  reset() {
-    hideOverlay('startOverlay');
-    hideOverlay('gameOverOverlay');
-    hideOverlay('pauseOverlay');
-    hideLeaderboard();
-    this.resetState();
-    this.gameLoop();
-  }
-
-  // Game variables
-  let gameOver = false;
-  let score = 0;
-  let flashOpacity = 0;
-=======
   resetState() {
-    this.player.x = this.gameWidth / 2 - this.playerWidth / 2;
-    this.player.y = this.gameHeight - this.playerHeight - 10;
+    this.player.x = this.gameWidth / 2 - this.player.width / 2;
+    this.player.y = this.gameHeight - this.player.height - 10;
     this.player.stopLeft();
     this.player.stopRight();
     this.bullet.isFired = false;
     this.enemies = [];
     this.enemyDirection = 1;
     this.enemySpeed = 1;
-    this.spawnEnemies();
-=======
-    this.spawnEnemies();
+
+    for (let r = 0; r < this.enemyRowCount; r++) {
+      for (let c = 0; c < this.enemyColumnCount; c++) {
+        const x = c * (30 + this.enemyPadding) + this.enemyOffsetLeft;
+        const y = r * (30 + this.enemyPadding) + this.enemyOffsetTop;
+        this.enemies.push(new Enemy(x, y, 30, 30, '#00ffff'));
+      }
+    }
+
     updateHUD({
       score: this.score,
       highScore: this.highScore,
       lives: this.lives,
       level: this.level,
     });
+  }
+
+  start() {
+    hideOverlay('startOverlay');
+    hideOverlay('gameOverOverlay');
+    hideOverlay('winOverlay');
+    hideOverlay('pauseOverlay');
+    hideLeaderboard();
+
+    document.addEventListener('keydown', this.handleKeyDown);
+    document.addEventListener('keyup', this.handleKeyUp);
     requestAnimationFrame(this.gameLoop);
   }
 
   reset() {
-    this.enemies = [];
-    this.spawnEnemies();
-    this.score = 0;
-    this.level = 1;
-    this.bullet.isFired = false;
-=======
-
-  reset() {
-    document.removeEventListener('keydown', this.handleKeyDown);
-    document.removeEventListener('keyup', this.handleKeyUp);
-=======
-    this.enemies = [];
-    this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-=======
-  }
-
-  start() {
-    this.lastTime = performance.now();
-    requestAnimationFrame((t) => this.loop(t));
-  }
-
-  reset() {
-    this.enemies = [];
-    this.particles = [];
-    this.bullet.isFired = false;
-    this.player.x = this.gameWidth / 2 - this.player.width / 2;
-    this.player.y = this.gameHeight - this.player.height - 10;
+    hideOverlay('startOverlay');
+    hideOverlay('gameOverOverlay');
+    hideOverlay('pauseOverlay');
+    hideLeaderboard();
 
     this.score = 0;
     this.lives = 3;
     this.level = 1;
-    this.gameOver = false;
-    this.gameWon = false;
-    this.isPaused = false;
-=======
-=======
-    this.paused = false;
-
-    this.spawnEnemies();
-    hideOverlay('gameOverOverlay');
- 
-  
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-  }
-
-  spawnEnemies() {
-    for (let row = 0; row < this.enemyRowCount; row++) {
-      for (let col = 0; col < this.enemyColumnCount; col++) {
-        const x = col * (this.enemyWidth + this.enemyPadding) + this.enemyOffsetLeft;
-        const y = row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff'));
-=======
-        const x = col * (30 + this.enemyPadding) + this.enemyOffsetLeft;
-        const y = row * (30 + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(new Enemy(x, y, 30, 30, '#ff00ff'));
-=======
-        const x =
-          col * (this.enemyWidth + this.enemyPadding) + this.enemyOffsetLeft;
-        const y =
-          row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-=======
-    for (let row = 0; row < ENEMY_ROWS; row++) {
-      for (let col = 0; col < ENEMY_COLUMNS; col++) {
-        const x = col * (ENEMY_WIDTH + ENEMY_PADDING) + ENEMY_OFFSET_LEFT;
-        const y = row * (ENEMY_HEIGHT + ENEMY_PADDING) + ENEMY_OFFSET_TOP;
-        this.enemies.push(
-          new Enemy(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, '#00ffff')
-=======
-    this.start();
+    this.resetState();
+    requestAnimationFrame(this.gameLoop);
   }
 
   handleKeyDown(e) {
     if (e.code === 'ArrowLeft') this.player.moveLeft();
     if (e.code === 'ArrowRight') this.player.moveRight();
     if (e.code === 'Space') {
-      if (!this.bullet.isFired) {
-        this.bullet.fire(
-          this.player.x + this.player.width / 2,
-          this.player.y
-        );
-        this.emitBulletParticles(
-          this.bullet.x + this.bullet.width / 2,
-          this.bullet.y
-        );
-      }
-    }
-    if (e.code === 'KeyP') this.togglePause();
-  }
-
-  handleKeyDown(e) {
-    if (e.code === 'ArrowLeft') this.player.moveLeft();
-    if (e.code === 'ArrowRight') this.player.moveRight();
-    if (e.code === 'Space') {
-      if (!this.bullet.isFired)
-        this.bullet.fire(
-          this.player.x + this.player.width / 2,
-          this.player.y
-        );
-    }
-  }
-
-  handleKeyUp(e) {
-    if (e.code === 'ArrowLeft') this.player.stopLeft();
-    if (e.code === 'ArrowRight') this.player.stopRight();
-  }
-
-  handleResize() {
-    this.gameWidth = window.innerWidth;
-    this.gameHeight = window.innerHeight;
-    this.canvas.width = this.gameWidth;
-    this.canvas.height = this.gameHeight;
-    if (this.bgCanvas) {
-      this.bgCanvas.width = this.gameWidth;
-      this.bgCanvas.height = this.gameHeight;
-      if (this.starfield) {
-        this.starfield.resize(this.gameWidth, this.gameHeight);
-      }
-    }
-  }
-
-=======
-  update() {
-    this.starfield.update();
-=======
-  handleKeyDown(event) {
-    if (event.key === 'ArrowLeft') {
-      this.player.moveLeft();
-    } else if (event.key === 'ArrowRight') {
-      this.player.moveRight();
-    } else if (event.key === ' ' || event.key === 'Spacebar') {
       if (!this.bullet.isFired) {
         const startX = this.player.x + this.player.width / 2;
         const startY = this.player.y;
         this.bullet.fire(startX, startY);
       }
-    } else if (event.key === 'p' || event.key === 'P') {
-      if (!this.pausePressed) {
-        this.togglePause();
-        this.pausePressed = true;
-=======
-=======
-=======
+    }
+  }
+
   handleKeyUp(e) {
     if (e.code === 'ArrowLeft') this.player.stopLeft();
     if (e.code === 'ArrowRight') this.player.stopRight();
   }
 
-  togglePause() {
-    this.paused = !this.paused;
-    if (this.paused) {
-      showOverlay('pauseOverlay');
-    } else {
-      hideOverlay('pauseOverlay');
-      this.lastTime = performance.now();
-      requestAnimationFrame((t) => this.loop(t));
-    }
-  }
-
-  emitPlayerParticles() {
-    for (let i = 0; i < 3; i++) {
-      this.particles.push({
-        x: this.player.x + this.player.width / 2,
-        y: this.player.y + this.player.height,
-        vx: (Math.random() - 0.5) * 2,
-        vy: Math.random() * 2 + 1,
-        life: 30,
-        color: this.primaryColor
-      });
-    }
-  }
-
-  emitBulletParticles(x, y) {
-    for (let i = 0; i < 5; i++) {
-      this.particles.push({
-        x,
-        y,
-        vx: (Math.random() - 0.5) * 3,
-        vy: (Math.random() - 0.5) * 3,
-        life: 20,
-        color: this.accentColor
-      });
-    }
-  }
-
-  // Shake the screen by translating the canvas
-  function screenShake(intensity, duration) {
-    const start = performance.now();
-    const originalTransform = canvas.style.transform;
-    function shake() {
-      const elapsed = performance.now() - start;
-      if (elapsed < duration) {
-        const dx = (Math.random() - 0.5) * intensity * 2;
-        const dy = (Math.random() - 0.5) * intensity * 2;
-        canvas.style.transform = `translate(${dx}px, ${dy}px)`;
-        requestAnimationFrame(shake);
-      } else {
-        canvas.style.transform = originalTransform;
-      }
-    }
-    requestAnimationFrame(shake);
-  }
-
-  // Flash the screen with a white overlay
-  function flashScreen(duration) {
-    flashOpacity = 0.5;
-    setTimeout(() => {
-      flashOpacity = 0;
-    }, duration);
-  }
-
-  // Update enemy positions and check collision with player and bullet
-  function updateEnemies() {
-    let wallHit = false;
-    let moveEnemiesDown = false;
-=======
-  spawnEnemies() {
-    for (let row = 0; row < this.enemyRows; row++) {
-      for (let col = 0; col < this.enemyCols; col++) {
-        const x =
-          col * (this.enemyWidth + this.enemyPadding) + this.enemyPadding;
-        const y =
-          row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(
-          new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff')
-        );
-      }
-    } else if (event.key.toLowerCase() === 'p') {
-      this.togglePause();
-    }
-  }
-
-  handleKeyUp(event) {
-    if (event.key === 'ArrowLeft') {
-      this.player.stopLeft();
-    } else if (event.key === 'ArrowRight') {
-      this.player.stopRight();
-    } else if (event.key === 'p' || event.key === 'P') {
-      this.pausePressed = false;
-    }
-  }
-
-        // Check collision with player
-        if (checkCollision(player, enemy)) {
-          gameOver = true;
-          screenShake(10, 300);
-          flashScreen(100);
-        }
-
-        // Check collision with bullet
-        if (bullet.isFired && checkCollision(bullet, enemy)) {
-          enemy.isAlive = false;
-          bullet.isFired = false;
-          score++;
-          playSound("explosion.wav");
-          screenShake(5, 300);
-          flashScreen(50);
-        }
-=======
-  togglePause() {
-    this.isPaused = !this.isPaused;
-    if (this.pauseOverlay) {
-      this.pauseOverlay.classList.toggle('show', this.isPaused);
-    }
-    if (!this.isPaused) {
-      this.gameLoop();
-=======
-  update(delta) {
-    this.starfield.update();
-
-    if (this.paused || this.gameOver) return;
-
-    if (this.player.isMovingLeft || this.player.isMovingRight) {
-      this.emitPlayerParticles();
-    }
-
-  togglePause() {
-    this.isPaused = !this.isPaused;
-    if (this.isPaused) {
-      showOverlay('pauseOverlay');
-    } else {
-      hideOverlay('pauseOverlay');
-    }
-  }
-
   update() {
-=======
-    if (this.starfield) this.starfield.update();
-=======
+    this.starfield?.update();
     this.player.update(this.gameWidth);
     this.bullet.update();
 
-    let hitEdge = false;
+    let edge = false;
     this.enemies.forEach((enemy) => {
-      if (!enemy.isAlive) return;
       enemy.update(this.enemyDirection, this.enemySpeed);
+      if (enemy.x < 0 || enemy.x + enemy.width > this.gameWidth) edge = true;
+    });
+
+    if (edge) {
+      this.enemyDirection *= -1;
+      this.enemies.forEach((enemy) => enemy.moveDown(20));
+    }
+
+    this.enemies.forEach((enemy) => {
       if (
-        (this.enemyDirection === 1 &&
-          enemy.x + enemy.width >= this.gameWidth) ||
-        (this.enemyDirection === -1 && enemy.x <= 0)
+        this.bullet.isFired &&
+        enemy.isAlive &&
+        this.bullet.x < enemy.x + enemy.width &&
+        this.bullet.x + this.bullet.width > enemy.x &&
+        this.bullet.y < enemy.y + enemy.height &&
+        this.bullet.y + this.bullet.height > enemy.y
       ) {
-        hitEdge = true;
-      }
-    });
-    if (hitEdge) {
-      this.enemyDirection *= -1;
-      this.enemies.forEach((e) => e.moveDown(20));
-=======
-      enemy.update(this.enemyDirection, this.enemySpeed);
-      if (enemy.x <= 0 || enemy.x + enemy.width >= this.gameWidth) {
-        hitEdge = true;
+        enemy.isAlive = false;
+        this.bullet.isFired = false;
+        this.score += 10;
       }
     });
 
-    if (hitEdge) {
-      this.enemyDirection *= -1;
-      for (const enemy of this.enemies) {
-        enemy.moveDown(ENEMY_HEIGHT);
-      }
-=======
-      this.enemies.forEach((e) => e.moveDown(this.enemyHeight));
-    }
-
-    if (this.bullet.isFired) {
-      this.enemies.forEach((enemy) => {
-        if (!enemy.isAlive) return;
-        const hit =
-=======
-        if (
-          enemy.isAlive &&
-          this.bullet.x < enemy.x + enemy.width &&
-          this.bullet.x + this.bullet.width > enemy.x &&
-          this.bullet.y < enemy.y + enemy.height &&
-          this.bullet.y + this.bullet.height > enemy.y;
-        if (hit) {
-          enemy.isAlive = false;
-          this.bullet.isFired = false;
-          this.score += 10;
-          if (this.score > this.highScore) {
-            this.highScore = this.score;
-            localStorage.setItem('highScore', this.highScore);
-          }
-=======
-          updateHUD({
-            score: this.score,
-            highScore: this.highScore,
-            lives: this.lives,
-            level: this.level
-          });
-          this.emitBulletParticles(
-            this.bullet.x + this.bullet.width / 2,
-            this.bullet.y
-          );
-        }
-      });
-=======
-      });
-    }
-=======
-      }
-    }
-
-    for (const enemy of this.enemies) {
-      if (enemy.isAlive && enemy.y + enemy.height >= this.player.y) {
-        this.gameOver = true;
-        this.gameWon = false;
-      }
-    }
-
-    if (this.enemies.every((e) => !e.isAlive)) {
-      this.gameOver = true;
-      this.gameWon = true;
-    }
+    updateHUD({
+      score: this.score,
+      highScore: Math.max(this.highScore, this.score),
+      lives: this.lives,
+      level: this.level,
+    });
   }
 
   draw() {
     this.context.clearRect(0, 0, this.gameWidth, this.gameHeight);
+    this.starfield?.draw();
     this.player.draw(this.context);
     this.bullet.draw(this.context);
-    for (const enemy of this.enemies) {
-      enemy.draw(this.context);
-    }
-  }
-
-  gameLoop() {
-    if (this.starfield) {
-      this.starfield.update();
-      this.starfield.draw();
-    }
-=======
-    if (this.isPaused) {
-      requestAnimationFrame(() => this.gameLoop());
-      return;
-    }
-
-    this.update();
-    this.draw();
-
-    if (this.gameOver) {
-=======
-    if (!this.isPaused) {
-      this.update();
-      this.draw();
-    }
-=======
-    this.update();
-    this.draw();
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-=======
-      if (!this.gameOver) {
-        requestAnimationFrame(() => this.gameLoop());
-      } else {
-        if (this.enemies.every((e) => !e.isAlive)) {
-          showOverlay('winOverlay');
-        } else {
-          showOverlay('gameOverOverlay');
-        }
-        saveScore('Player', this.score);
-        showLeaderboard();
-      }
-=======
-=======
-    if (!this.gameOver) {
-      requestAnimationFrame(() => this.gameLoop());
-    } else {
-      const overlayId = this.gameWon ? 'winOverlay' : 'gameOverOverlay';
-      showOverlay(overlayId);
-      saveScore('Player', this.score);
-      showLeaderboard();
-    } else {
-      requestAnimationFrame(() => this.gameLoop());
-    }
-  }
-}
-=======
-  }
-}
-
-let currentGame;
-=======
-=======
-=======
-      updateLeaderboard();
-    }
-  }
-
-    this.enemies = this.enemies.filter((e) => e.isAlive);
-
-    if (this.enemies.length === 0) {
-      this.level++;
-      this.enemySpeed += 0.2;
-      this.enemyRows++;
-      this.spawnEnemies();
-      updateHUD({
-        score: this.score,
-        highScore: this.highScore,
-        lives: this.lives,
-        level: this.level
-      });
-    }
-
-    this.particles.forEach((p) => {
-      p.x += p.vx;
-      p.y += p.vy;
-      p.life--;
-    });
-    this.particles = this.particles.filter((p) => p.life > 0);
-
-    const reachedBottom = this.enemies.some(
-      (e) => e.y + e.height >= this.player.y
-    );
-  }
-
-  endGame() {
-    this.gameOver = true;
-    this.highScore = Math.max(this.highScore, this.score);
-    localStorage.setItem('highScore', this.highScore);
-    if (this.gameOverOverlay) this.gameOverOverlay.classList.add('show');
-  }
-
-  update() {
-    this.player.update(this.gameWidth);
-    if (this.player.isMovingLeft || this.player.isMovingRight) {
-      this.emitPlayerParticles();
-    }
-    this.bullet.update();
-    if (this.bullet.isFired) {
-      this.emitBulletParticles();
-    }
-
-    if (this.bullet.isFired) {
-      this.enemies.forEach((enemy) => {
-        if (enemy.isAlive && this.checkCollision(this.bullet, enemy)) {
-          enemy.isAlive = false;
-          this.bullet.isFired = false;
-          this.score += 10;
-          if (this.score > this.highScore) {
-            this.highScore = this.score;
-          }
-          this.updateHUD();
-        }
-=======
-    if (reachedBottom) {
-      this.lives--;
-      updateHUD({
-        score: this.score,
-        highScore: this.highScore,
-        lives: this.lives,
-        level: this.level
-      });
-      if (this.lives <= 0) {
-        this.gameOver = true;
-        saveScore('Player', this.score);
-        showLeaderboard();
-        showOverlay('gameOverOverlay');
-      } else {
-        this.enemies = [];
-        this.spawnEnemies();
-      }
-    }
-  }
-
-  draw() {
-    this.ctx.clearRect(0, 0, this.gameWidth, this.gameHeight);
-    this.player.draw(this.ctx);
-    this.bullet.draw(this.ctx);
-
-    // Draw flash overlay
-    if (flashOpacity > 0) {
-      context.fillStyle = `rgba(255, 255, 255, ${flashOpacity})`;
-      context.fillRect(0, 0, gameWidth, gameHeight);
-    }
-
-    // Request next animation frame
-    requestAnimationFrame(gameLoop);
-=======
-    
-    this.enemies.forEach((e) => e.draw(this.ctx));
+    this.enemies.forEach((enemy) => enemy.draw(this.context));
   }
 
   gameLoop() {
@@ -799,100 +183,3 @@ let currentGame;
 }
 
 export { updateHUD, saveScore, showLeaderboard, hideLeaderboard };
-=======
-    this.enemies.forEach((enemy) => enemy.draw(this.ctx));
-    this.particles.forEach((p) => {
-      this.ctx.fillStyle = p.color;
-      this.ctx.fillRect(p.x, p.y, 2, 2);
-    });
-  }
-=======
-  // Start the game loop
-  updateHUD({ score, highScore, lives, level });
-  gameLoop();
-}
-
-
-function startGame() {
-  hideOverlay('startOverlay');
-  hideOverlay('gameOverOverlay');
-  hideOverlay('winOverlay');
-  hideOverlay('pauseOverlay');
-=======
-  init();
-}
-
-function resetGame() {
-  startGame();
-}
-=======
-=======
-  hideLeaderboard();
-  if (!currentGame) {
-    currentGame = new Game();
-  } else {
-    currentGame.reset();
-  }
-  currentGame.start();
-}
-
-function resetGame() {
-  startGame();
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  const startButton = document.getElementById('startButton');
-  const restartButton = document.getElementById('restartButton');
-  const playAgainButton = document.getElementById('playAgainButton');
-  const leaderboardButton = document.getElementById('leaderboardButton');
-  const closeLeaderboard = document.getElementById('closeLeaderboard');
-  if (startButton) startButton.addEventListener('click', startGame);
-  if (restartButton) restartButton.addEventListener('click', resetGame);
-  if (playAgainButton) playAgainButton.addEventListener('click', resetGame);
-  if (leaderboardButton)
-    leaderboardButton.addEventListener('click', showLeaderboard);
-  if (closeLeaderboard)
-    closeLeaderboard.addEventListener('click', hideLeaderboard);
-});
-=======
-
-=======
-  loop(timestamp) {
-    const delta = timestamp - this.lastTime;
-    this.lastTime = timestamp;
-
-    this.update(delta);
-    this.starfield.draw();
-    this.draw();
-
-    if (!this.paused && !this.gameOver) {
-      requestAnimationFrame((t) => this.loop(t));
-    }
-  }
-}
-
-=======
-
-=======
-=======
-// Attach button handlers after DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-  document.getElementById('startButton')?.addEventListener('click', startGame);
-  document.getElementById('restartButton')?.addEventListener('click', resetGame);
-});
-=======
-=======
-
-
-=======
-// Attach button handlers after page load
-window.onload = function () {
-  document
-    .getElementById("startButton")
-    .addEventListener("click", startGame);
-  document
-    .getElementById("restartButton")
-    .addEventListener("click", resetGame);
-};
-
-

--- a/hud.js
+++ b/hud.js
@@ -16,16 +16,6 @@ function initHUD() {
   updateLeaderboard();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-=======
-  const leaderboardButton = document.getElementById('leaderboardButton');
-  const closeLeaderboard = document.getElementById('closeLeaderboard');
-  if (leaderboardButton)
-    leaderboardButton.addEventListener('click', showLeaderboard);
-  if (closeLeaderboard)
-    closeLeaderboard.addEventListener('click', hideLeaderboard);
-});
-
 function updateHUD({ score, highScore, lives, level }) {
   if (scoreEl) scoreEl.textContent = score;
   if (highScoreEl) highScoreEl.textContent = highScore;

--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
-=======
-  <link rel="stylesheet" type="text/css" href="styles.css" />
 </head>
 <body>
   <div id="gameContainer">
@@ -58,22 +56,12 @@
     </div>
   </div>
 
-  <script src="starfield.js"></script>
-=======
   <script type="module">
     import Game from './game.js';
     import { initGameUI } from './ui.js';
 
     const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
+    initGameUI(game);
   </script>
-=======
-=======
-    const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-  </script>
-=======
-  <script type="module" src="./game.js"></script>
 </body>
 </html>
-

--- a/ui.js
+++ b/ui.js
@@ -1,4 +1,4 @@
-import { initHUD } from './hud.js';
+import { initHUD, showLeaderboard, hideLeaderboard } from './hud.js';
 
 function initGameUI(game) {
   initHUD();
@@ -6,12 +6,18 @@ function initGameUI(game) {
   const startButton = document.getElementById('startButton');
   const restartButton = document.getElementById('restartButton');
   const playAgainButton = document.getElementById('playAgainButton');
+  const leaderboardButton = document.getElementById('leaderboardButton');
+  const closeLeaderboard = document.getElementById('closeLeaderboard');
 
-=======
   if (startButton) startButton.addEventListener('click', () => game.start());
-  if (restartButton) restartButton.addEventListener('click', () => game.reset());
+  if (restartButton)
+    restartButton.addEventListener('click', () => game.reset());
   if (playAgainButton)
     playAgainButton.addEventListener('click', () => game.reset());
+  if (leaderboardButton)
+    leaderboardButton.addEventListener('click', showLeaderboard);
+  if (closeLeaderboard)
+    closeLeaderboard.addEventListener('click', hideLeaderboard);
 }
 
 export { initGameUI };


### PR DESCRIPTION
## Summary
- centralize UI and HUD initialization through `initGameUI`
- instantiate `Game` in `index.html` and initialize UI on load
- simplify game loop setup and remove `window.onload` logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3adbd7a708328ae8d3b268d9fbd72