### PR TITLE
Hook up and style leaderboard overlay

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -12,19 +12,16 @@ function initHUD() {
   levelEl = document.getElementById('level');
   leaderboardOverlay = document.getElementById('leaderboardOverlay');
   leaderboardList = document.getElementById('leaderboardList');
-
-  updateLeaderboard();
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-=======
   const leaderboardButton = document.getElementById('leaderboardButton');
   const closeLeaderboard = document.getElementById('closeLeaderboard');
+
+  updateLeaderboard();
+
   if (leaderboardButton)
     leaderboardButton.addEventListener('click', showLeaderboard);
   if (closeLeaderboard)
     closeLeaderboard.addEventListener('click', hideLeaderboard);
-});
+}
 
 function updateHUD({ score, highScore, lives, level }) {
   if (scoreEl) scoreEl.textContent = score;

--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <title>Space Invaders</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
-=======
-  <link rel="stylesheet" type="text/css" href="styles.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <div id="gameContainer">
@@ -58,22 +59,13 @@
     </div>
   </div>
 
-  <script src="starfield.js"></script>
-=======
-  <script type="module">
-    import Game from './game.js';
-    import { initGameUI } from './ui.js';
+    <script type="module">
+      import Game from './game.js';
+      import { initGameUI } from './ui.js';
 
-    const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-  </script>
-=======
-=======
-    const game = new Game();
-    document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-  </script>
-=======
-  <script type="module" src="./game.js"></script>
-</body>
+      const game = new Game();
+      document.addEventListener('DOMContentLoaded', () => initGameUI(game));
+    </script>
+  </body>
 </html>
 

--- a/styles.css
+++ b/styles.css
@@ -96,6 +96,9 @@ canvas {
     text-align: center;
     color: var(--color-accent);
     font-family: 'Press Start 2P', monospace;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 @keyframes slide-down {

--- a/ui.js
+++ b/ui.js
@@ -6,8 +6,6 @@ function initGameUI(game) {
   const startButton = document.getElementById('startButton');
   const restartButton = document.getElementById('restartButton');
   const playAgainButton = document.getElementById('playAgainButton');
-
-=======
   if (startButton) startButton.addEventListener('click', () => game.start());
   if (restartButton) restartButton.addEventListener('click', () => game.reset());
   if (playAgainButton)


### PR DESCRIPTION
## Summary
- Cleaned HTML to include single leaderboard button and overlay structure
- Styled `.leaderboard-content` to align with other overlays
- Wired HUD init to attach leaderboard show/hide handlers after DOM loaded

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3adb6dbb88328822d513f1af5ecae