### PR TITLE
feat: improve mobile controls and canvas sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Space Invaders</title>
-=======
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
-=======
-=======
-  <link rel="stylesheet" href="styles.css">
-
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link
-    href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap"
-    rel="stylesheet"
-  />
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -64,34 +52,17 @@
   </div>
 
   <div id="mobileControls">
-    <button id="leftButton">Left</button>
-    <button id="shootButton">Shoot</button>
-    <button id="rightButton">Right</button>
+    <button id="leftButton" aria-label="Move left">Left</button>
+    <button id="shootButton" aria-label="Shoot">Shoot</button>
+    <button id="rightButton" aria-label="Move right">Right</button>
   </div>
 
-  <script type="module" src="game.js"></script>
-=======
-    <script type="module">
-      import Game from './game.js';
-      import { initGameUI } from './ui.js';
-
-      const game = new Game();
-      document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-    </script>
-  </body>
-=======
   <script type="module">
     import Game from './game.js';
     import { initGameUI } from './ui.js';
 
     const game = new Game();
-
-    =======
     document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-=======
-=======
-=======
-    initGameUI(game);
   </script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -166,17 +166,21 @@ canvas {
 
 /* Mobile controls */
 #mobileControls {
-    position: absolute;
-    bottom: 20px;
+    position: fixed;
+    bottom: 2vh;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
-    gap: 20px;
+    gap: 2vh;
+    z-index: 5;
 }
 
 #mobileControls button {
-    width: 60px;
-    height: 60px;
+    width: 12vh;
+    height: 12vh;
+    max-width: 80px;
+    max-height: 80px;
+    font-size: 0.75rem;
 }
 
 @media (min-width: 768px) {

--- a/ui.js
+++ b/ui.js
@@ -1,6 +1,4 @@
 import { initHUD, showLeaderboard, hideLeaderboard } from './hud.js';
-=======
-import { initHUD } from './hud.js';
 import { hideOverlay } from './game.js';
 
 function initGameUI(game) {
@@ -9,58 +7,13 @@ function initGameUI(game) {
   const startButton = document.getElementById('startButton');
   const restartButton = document.getElementById('restartButton');
   const playAgainButton = document.getElementById('playAgainButton');
-=======
-=======
-=======
   const leaderboardButton = document.getElementById('leaderboardButton');
   const closeLeaderboard = document.getElementById('closeLeaderboard');
 
-  if (startButton) startButton.addEventListener('click', () => game.start());
-  if (restartButton)
-    restartButton.addEventListener('click', () => game.reset());
-  if (playAgainButton)
-    playAgainButton.addEventListener('click', () => game.reset());
   if (leaderboardButton)
     leaderboardButton.addEventListener('click', showLeaderboard);
   if (closeLeaderboard)
     closeLeaderboard.addEventListener('click', hideLeaderboard);
-=======
-=======
-
-  const leftButton = document.getElementById('leftButton');
-  const rightButton = document.getElementById('rightButton');
-  const shootButton = document.getElementById('shootButton');
-
-  const bindMove = (btn, start, stop) => {
-    btn.addEventListener('pointerdown', start);
-    btn.addEventListener('pointerup', stop);
-    btn.addEventListener('pointerleave', stop);
-  };
-
-  if (leftButton)
-    bindMove(
-      leftButton,
-      () => game.player.moveLeft(),
-      () => game.player.stopLeft()
-    );
-
-  if (rightButton)
-    bindMove(
-      rightButton,
-      () => game.player.moveRight(),
-      () => game.player.stopRight()
-    );
-
-  if (shootButton) {
-    shootButton.addEventListener('click', () => {
-      if (!game.bullet.isFired) {
-        game.bullet.fire(
-          game.player.x + game.player.width / 2,
-          game.player.y
-        );
-      }
-    });
-  }
 
   if (startButton) {
     startButton.addEventListener('click', () => {
@@ -80,7 +33,81 @@ function initGameUI(game) {
       hideOverlay('winOverlay');
     });
   }
+
+  // Mobile controls
+  const leftButton = document.getElementById('leftButton');
+  const rightButton = document.getElementById('rightButton');
+  const shootButton = document.getElementById('shootButton');
+
+  const bindMove = (btn, start, stop) => {
+    const startHandler = (e) => {
+      e.preventDefault();
+      start();
+    };
+    const endHandler = (e) => {
+      e.preventDefault();
+      stop();
+    };
+    btn.addEventListener('touchstart', startHandler);
+    btn.addEventListener('mousedown', startHandler);
+    btn.addEventListener('touchend', endHandler);
+    btn.addEventListener('touchcancel', endHandler);
+    btn.addEventListener('mouseup', endHandler);
+    btn.addEventListener('mouseleave', endHandler);
+  };
+
+  if (leftButton)
+    bindMove(leftButton, () => game.player.moveLeft(), () => game.player.stopLeft());
+
+  if (rightButton)
+    bindMove(rightButton, () => game.player.moveRight(), () => game.player.stopRight());
+
+  if (shootButton) {
+    const fire = (e) => {
+      e.preventDefault();
+      if (!game.bullet.isFired) {
+        game.bullet.fire(
+          game.player.x + game.player.width / 2,
+          game.player.y
+        );
+      }
+    };
+    shootButton.addEventListener('touchstart', fire);
+    shootButton.addEventListener('click', fire);
+  }
+
+  // Responsive canvas sizing
+  const resizeCanvas = () => {
+    const container = document.getElementById('gameContainer');
+    const bgCanvas = document.getElementById('bgCanvas');
+    const gameCanvas = document.getElementById('gameCanvas');
+    const aspect = 4 / 3;
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+
+    if (width / height > aspect) {
+      width = height * aspect;
+    } else {
+      height = width / aspect;
+    }
+
+    container.style.width = `${width}px`;
+    container.style.height = `${height}px`;
+    bgCanvas.width = width;
+    bgCanvas.height = height;
+    gameCanvas.width = width;
+    gameCanvas.height = height;
+
+    game.gameWidth = width;
+    game.gameHeight = height;
+    if (game.starfield && typeof game.starfield.resize === 'function') {
+      game.starfield.resize(width, height);
+    }
+  };
+
+  window.addEventListener('resize', resizeCanvas);
+  resizeCanvas();
 }
 
 export { initGameUI };
-


### PR DESCRIPTION
## Summary
- add ARIA labels and touch handlers for mobile controls
- make mobile control buttons responsive
- resize canvas on window changes to keep 4:3 aspect ratio

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1282f208328b397356af4d4094e