### PR TITLE
feat: centralize config and level scaling

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,31 @@
+export const PLAYER = {
+  WIDTH: 40,
+  HEIGHT: 30,
+  SPEED: 5,
+};
+
+export const BULLET = {
+  WIDTH: 5,
+  HEIGHT: 15,
+  SPEED: 7,
+};
+
+export const ENEMY = {
+  WIDTH: 30,
+  HEIGHT: 30,
+  ROWS: 5,
+  COLUMNS: 10,
+  PADDING: 10,
+  OFFSET_TOP: 50,
+  OFFSET_LEFT: 50,
+  BASE_SPEED: 1,
+  SPEED_INCREMENT: 0.2,
+};
+
+export function getLevelConfig(level) {
+  return {
+    playerSpeed: PLAYER.SPEED,
+    bulletSpeed: BULLET.SPEED,
+    enemySpeed: ENEMY.BASE_SPEED + (level - 1) * ENEMY.SPEED_INCREMENT,
+  };
+}

--- a/game.js
+++ b/game.js
@@ -2,55 +2,15 @@ import Player from './player.js';
 import Bullet from './bullet.js';
 import Enemy from './enemy.js';
 import Starfield from './starfield.js';
-import { updateHUD } from './hud.js';
-import { initGameUI } from './ui.js';
-
-function showOverlay(id) {
-=======
 import {
   updateHUD,
   saveScore,
   showLeaderboard,
   hideLeaderboard,
 } from './hud.js';
-=======
-=======
-=======
-=======
-
-
-export function showOverlay(id) {
-  const el = document.getElementById(id);
-  if (el) el.classList.add('show');
-}
-
-export function hideOverlay(id) {
-  const el = document.getElementById(id);
-  if (el) el.classList.remove('show');
-}
-
-// Game configuration constants
-const PLAYER_WIDTH = 40;
-const PLAYER_HEIGHT = 30;
-const PLAYER_SPEED = 5;
-
-const BULLET_WIDTH = 5;
-const BULLET_HEIGHT = 15;
-const BULLET_SPEED = 7;
-
-const ENEMY_WIDTH = 30;
-const ENEMY_HEIGHT = 30;
-const ENEMY_ROWS = 5;
-const ENEMY_COLUMNS = 10;
-const ENEMY_PADDING = 10;
-const ENEMY_OFFSET_TOP = 50;
-const ENEMY_OFFSET_LEFT = 50;
-const ENEMY_BASE_SPEED = 1;
+import { PLAYER, BULLET, ENEMY, getLevelConfig } from './config.js';
 
 function showOverlay(id) {
-=======
-// Overlay helpers
-export function showOverlay(id) {
   const el = document.getElementById(id);
   if (el) el.classList.add('show');
 }
@@ -60,10 +20,6 @@ function hideOverlay(id) {
   if (el) el.classList.remove('show');
 }
 
-function allEnemiesDefeated(enemies) {
-  return enemies.every((enemy) => !enemy.isAlive);
-}
-
 export default class Game {
   constructor() {
     // canvases
@@ -71,245 +27,44 @@ export default class Game {
     this.ctx = this.canvas.getContext('2d');
     const bgCanvas = document.getElementById('bgCanvas');
     this.starfield = bgCanvas ? new Starfield(bgCanvas) : null;
-=======
-    this.ctx = this.canvas.getContext('2d');
-    const bgCanvas = document.getElementById('bgCanvas');
-    this.starfield = bgCanvas ? new Starfield(bgCanvas) : null;
-=======
-    this.canvas = document.getElementById('gameCanvas');
-    this.context = this.canvas.getContext('2d');
 
-    const bgCanvas = document.getElementById('bgCanvas');
-    this.starfield = bgCanvas ? new Starfield(bgCanvas) : null;
-    this.canvas = document.getElementById('gameCanvas');
-    this.context = this.canvas.getContext('2d');
-    const bgCanvas = document.getElementById('bgCanvas');
-    if (bgCanvas) this.starfield = new Starfield(bgCanvas);
-=======
-=======
-
-    // Game constants
     this.gameWidth = this.canvas.width;
     this.gameHeight = this.canvas.height;
-    this.playerWidth = 40;
-    this.playerHeight = 30;
-    this.playerSpeed = 5;
-    this.bulletWidth = 5;
-    this.bulletHeight = 15;
-    this.bulletSpeed = 7;
-    this.enemyWidth = 30;
-    this.enemyHeight = 30;
-    // Canvas and starfield
-=======
-    this.enemyRowCount = 5;
-    this.enemyColumnCount = 10;
-    this.enemyPadding = 10;
-    this.enemyOffsetTop = 50;
-    this.enemyOffsetLeft = 50;
 
-    // Entities
+      // entities
+      this.level = 1;
+      const levelConfig = getLevelConfig(this.level);
     this.player = new Player(
-      this.gameWidth / 2 - this.playerWidth / 2,
-      this.gameHeight - this.playerHeight - 10,
-      this.playerWidth,
-      this.playerHeight,
-      this.playerSpeed,
+      this.gameWidth / 2 - PLAYER.WIDTH / 2,
+      this.gameHeight - PLAYER.HEIGHT - 10,
+      PLAYER.WIDTH,
+      PLAYER.HEIGHT,
+      levelConfig.playerSpeed,
       '#00ff00'
     );
     this.bullet = new Bullet(
-      this.bulletWidth,
-      this.bulletHeight,
-      this.bulletSpeed,
-=======
-=======
-export default class Game {
-  constructor() {
-    this.canvas = document.getElementById('gameCanvas');
-    this.ctx = this.canvas.getContext('2d');
-    const bgCanvas = document.getElementById('bgCanvas');
-    this.starfield = new Starfield(bgCanvas);
-
-    this.gameWidth = this.canvas.width;
-    this.gameHeight = this.canvas.height;
-
-    this.gameWidth = this.canvas.width;
-    this.gameHeight = this.canvas.height;
-
-    // Player
-=======
-    // entities
-    this.player = new Player(
-      this.gameWidth / 2 - PLAYER_WIDTH / 2,
-      this.gameHeight - PLAYER_HEIGHT - 10,
-      PLAYER_WIDTH,
-      PLAYER_HEIGHT,
-      PLAYER_SPEED,
-      '#00ff00'
-    );
-    this.bullet = new Bullet(
-      BULLET_WIDTH,
-      BULLET_HEIGHT,
-      BULLET_SPEED,
+      BULLET.WIDTH,
+      BULLET.HEIGHT,
+      levelConfig.bulletSpeed,
       '#ff0000'
     );
     this.enemies = [];
 
     // enemy movement
     this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
+    this.enemySpeed = levelConfig.enemySpeed;
 
-    // game state
-    this.score = 0;
-    this.highScore =
-      parseInt(localStorage.getItem('highScore'), 10) || 0;
-    this.lives = 3;
-    this.level = 1;
-    this.isPaused = false;
-    this.gameOver = false;
+      // game state
+      this.score = 0;
+      this.highScore =
+        parseInt(localStorage.getItem('highScore'), 10) || 0;
+      this.lives = 3;
+      this.isPaused = false;
+      this.gameOver = false;
 
     // overlays
-=======
-
-    this.enemies = [];
-    this.enemySpeed = ENEMY_BASE_SPEED;
-    // Colors
-    const styles = getComputedStyle(document.documentElement);
-    this.primaryColor =
-      styles.getPropertyValue('--color-primary').trim() || '#00ff00';
-    this.accentColor =
-      styles.getPropertyValue('--color-accent').trim() || '#ff0000';
-=======
-
-    this.player = new Player(
-      this.gameWidth / 2 - 20,
-      this.gameHeight - 40,
-      40,
-      30,
-      5,
-      '#00ff00'
-    );
-
-    // Bullet
-    this.bullet = new Bullet(5, 15, 7, '#ff0000');
-=======
-    this.enemyRowCount = 5;
-    this.enemyColumnCount = 10;
-    this.enemyPadding = 10;
-    this.enemyOffsetTop = 50;
-    this.enemyOffsetLeft = 50;
-    this.enemies = [];
-    this.enemyDirection = 1;
-    this.enemySpeed = 1;
-    this.spawnEnemies();
-    this.bullet = new Bullet(5, 15, 7, this.accentColor);
-
-    // Enemy configuration
-    this.enemyRows = 5;
-    this.enemyCols = 10;
-    this.enemyWidth = 30;
-    this.enemyHeight = 30;
-    this.enemyPadding = 10;
-    this.enemyOffsetTop = 50;
-    this.enemyOffsetLeft = 50;
-    this.enemyDirection = 1;
-    this.enemySpeed = 1;
-    this.enemies = [];
-=======
-
-    // Entities
-    this.player = new Player(
-      this.gameWidth / 2 - this.playerWidth / 2,
-      this.gameHeight - this.playerHeight - 10,
-      this.playerWidth,
-      this.playerHeight,
-      this.playerSpeed,
-=======
-=======
-      this.gameWidth / 2 - PLAYER_WIDTH / 2,
-      this.gameHeight - PLAYER_HEIGHT - 10,
-      PLAYER_WIDTH,
-      PLAYER_HEIGHT,
-      PLAYER_SPEED,
-      '#00ff00'
-    );
-
-    this.bullet = new Bullet(
-      BULLET_WIDTH,
-      BULLET_HEIGHT,
-      BULLET_SPEED,
-      '#ff0000'
-    );
-
-    this.enemies = [];
-    this.spawnEnemies();
-    this.enemySpeed = 1;
-=======
-=======
-    this.enemySpeed = ENEMY_BASE_SPEED;
-    this.enemyDirection = 1;
-    this.spawnEnemies();
-=======
-    this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-
-    // Game state
-    this.score = 0;
-    this.highScore = parseInt(localStorage.getItem('highScore') || '0', 10);
-    this.lives = 3;
-    this.level = 1;
-    this.gameOver = false;
-
-    // Bindings
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
-    this.gameLoop = this.gameLoop.bind(this);
-
-    this.spawnEnemies();
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-  }
-
-  spawnEnemies() {
-    this.enemies = [];
-    for (let row = 0; row < this.enemyRows; row++) {
-      for (let col = 0; col < this.enemyCols; col++) {
-        const x =
-          col * (this.enemyWidth + this.enemyPadding) + this.enemyOffsetLeft;
-        const y =
-          row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(
-          new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff')
-        );
-      }
-    }
-=======
-
-    this.gameLoop = this.gameLoop.bind(this);
-=======
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
-
-    this.resetState();
-  }
-
-  resetState() {
-    this.player.x = this.gameWidth / 2 - this.player.width / 2;
-    this.player.y = this.gameHeight - this.player.height - 10;
-=======
-=======
-
-    this.isPaused = false;
-    this.gameOver = false;
-    this.gameWon = false;
-    this.lastTime = 0;
-
     this.startOverlay = document.getElementById('startOverlay');
     this.gameOverOverlay = document.getElementById('gameOverOverlay');
-    this.winOverlay = document.getElementById('winOverlay');
     this.pauseOverlay = document.getElementById('pauseOverlay');
 
     // bind methods
@@ -322,102 +77,16 @@ export default class Game {
     window.addEventListener('keyup', this.handleKeyUp);
 
     this.resetState();
-=======
-    // Bind handlers
-    this.paused = false;
-    this.lastTime = 0;
-=======
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
-  }
-=======
-=======
-
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-    this.handleKeyUp = this.handleKeyUp.bind(this);
-
-    window.addEventListener('keydown', this.handleKeyDown);
-    window.addEventListener('keyup', this.handleKeyUp);
-
-    this.gameLoop = this.gameLoop.bind(this);
-
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-  }
-
-  start() {
-    hideOverlay('startOverlay');
-    hideOverlay('gameOverOverlay');
-    hideOverlay('winOverlay');
-    hideOverlay('pauseOverlay');
-    this.isPaused = false;
-    this.gameOver = false;
-    this.gameWon = false;
-    this.lastTime = 0;
-    requestAnimationFrame(this.gameLoop);
   }
 
   resetState() {
-=======
-    // Reset player position and movement
-    this.player.x = this.gameWidth / 2 - this.playerWidth / 2;
-    this.player.y = this.gameHeight - this.playerHeight - 10;
-    this.player.stopLeft();
-    this.player.stopRight();
-
-    // Reset bullet
     this.bullet.isFired = false;
-
-    // Reset enemies
     this.enemies = [];
     this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-=======
-    this.enemySpeed = 1;
-    this.spawnEnemies();
-=======
-
-    for (let r = 0; r < this.enemyRowCount; r++) {
-      for (let c = 0; c < this.enemyColumnCount; c++) {
-        const x = c * (30 + this.enemyPadding) + this.enemyOffsetLeft;
-        const y = r * (30 + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(new Enemy(x, y, 30, 30, '#00ffff'));
-      }
-    }
-
-=======
-    this.spawnEnemies();
-
-    // Reset score and state
-    this.score = 0;
-    this.lives = 3;
-    this.level = 1;
-    this.bullet.isFired = false;
-
-  reset() {
-    document.removeEventListener('keydown', this.handleKeyDown);
-    document.removeEventListener('keyup', this.handleKeyUp);
-    this.enemies = [];
-    this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-=======
-    this.gameOver = false;
-    this.gameWon = false;
-    this.isPaused = false;
-
-=======
-  reset() {
-    this.score = 0;
-    this.lives = 3;
-    this.level = 1;
-    this.bullet.isFired = false;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-    this.enemyDirection = 1;
-=======
+    const levelConfig = getLevelConfig(this.level);
+    this.player.speed = levelConfig.playerSpeed;
+    this.bullet.speed = levelConfig.bulletSpeed;
+    this.enemySpeed = levelConfig.enemySpeed;
     this.spawnEnemies();
     updateHUD({
       score: this.score,
@@ -428,33 +97,6 @@ export default class Game {
   }
 
   start() {
-    hideOverlay('startOverlay');
-    hideOverlay('gameOverOverlay');
-    document.addEventListener('keydown', this.handleKeyDown);
-    document.addEventListener('keyup', this.handleKeyUp);
-    this.gameOver = false;
-    this.gameLoop();
-  }
-
-  reset() {
-    hideOverlay('gameOverOverlay');
-    this.score = 0;
-    this.lives = 3;
-    this.level = 1;
-    this.bullet.isFired = false;
-    this.player.x = this.gameWidth / 2 - this.player.width / 2;
-=======
-=======
-    hideOverlay('winOverlay');
-    hideOverlay('pauseOverlay');
-    hideLeaderboard();
-
-    document.addEventListener('keydown', this.handleKeyDown);
-    document.addEventListener('keyup', this.handleKeyUp);
-    requestAnimationFrame(this.gameLoop);
-  }
-
-  reset() {
     hideOverlay('startOverlay');
     hideOverlay('gameOverOverlay');
     hideOverlay('pauseOverlay');
@@ -472,89 +114,18 @@ export default class Game {
   }
 
   reset() {
-=======
-    this.gameOver = false;
-    this.gameWon = false;
-    this.isPaused = false;
-    this.paused = false;
-=======
-    this.resetState();
-    requestAnimationFrame(this.gameLoop);
-  }
-
-  handleKeyDown(e) {
-    if (e.code === 'ArrowLeft') this.player.moveLeft();
-    if (e.code === 'ArrowRight') this.player.moveRight();
-    if (e.code === 'Space') {
-=======
-    this.resetState();
-    requestAnimationFrame(() => this.gameLoop());
-  }
-
-  resetState() {
-    this.player.x = this.gameWidth / 2 - PLAYER_WIDTH / 2;
-    this.player.y = this.gameHeight - PLAYER_HEIGHT - 10;
-    this.player.stopLeft();
-    this.player.stopRight();
-    this.bullet.isFired = false;
-    this.enemies = [];
-    this.enemyDirection = 1;
-    this.enemySpeed = ENEMY_BASE_SPEED;
-    this.spawnEnemies();
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-    this.gameOver = false;
-    this.gameLoop();
-=======
     this.start();
   }
 
   spawnEnemies() {
-=======
-
-    for (let row = 0; row < this.enemyRowCount; row++) {
-      for (let col = 0; col < this.enemyColumnCount; col++) {
-        const x = col * (this.enemyWidth + this.enemyPadding) + this.enemyOffsetLeft;
-        const y = row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff'));
-        const x = col * (30 + this.enemyPadding) + this.enemyOffsetLeft;
-        const y = row * (30 + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(new Enemy(x, y, 30, 30, '#ff00ff'));
+    for (let row = 0; row < ENEMY.ROWS; row++) {
+      for (let col = 0; col < ENEMY.COLUMNS; col++) {
         const x =
-          col * (this.enemyWidth + this.enemyPadding) + this.enemyOffsetLeft;
+          col * (ENEMY.WIDTH + ENEMY.PADDING) + ENEMY.OFFSET_LEFT;
         const y =
-          row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-    for (let row = 0; row < ENEMY_ROWS; row++) {
-      for (let col = 0; col < ENEMY_COLUMNS; col++) {
-        const x =
-          col * (ENEMY_WIDTH + ENEMY_PADDING) + ENEMY_OFFSET_LEFT;
-        const y =
-          row * (ENEMY_HEIGHT + ENEMY_PADDING) + ENEMY_OFFSET_TOP;
+          row * (ENEMY.HEIGHT + ENEMY.PADDING) + ENEMY.OFFSET_TOP;
         this.enemies.push(
-          new Enemy(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, '#00ffff')
-=======
-    this.start();
-  }
-
-  handleKeyDown(e) {
-    if (e.code === 'ArrowLeft') this.player.moveLeft();
-    if (e.code === 'ArrowRight') this.player.moveRight();
-    if (e.code === 'Space') {
-      if (!this.bullet.isFired) {
-        this.bullet.fire(
-          this.player.x + this.player.width / 2,
-          this.player.y
-        );
-        this.emitBulletParticles(
-          this.bullet.x + this.bullet.width / 2,
-          this.bullet.y
-=======
-        this.enemies.push(
-          new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff')
+          new Enemy(x, y, ENEMY.WIDTH, ENEMY.HEIGHT, '#00ffff')
         );
       }
     }
@@ -563,23 +134,6 @@ export default class Game {
   handleKeyDown(e) {
     if (e.code === 'ArrowLeft') this.player.moveLeft();
     if (e.code === 'ArrowRight') this.player.moveRight();
-    if (e.code === 'Space' && !this.bullet.isFired) {
-      this.bullet.fire(this.player.x + this.player.width / 2, this.player.y);
-    }
-  }
-
-  handleKeyUp(e) {
-    if (e.code === 'ArrowLeft') this.player.stopLeft();
-    if (e.code === 'ArrowRight') this.player.stopRight();
-  }
-
-  update() {
-    if (this.starfield) {
-      this.starfield.update();
-      this.starfield.draw();
-    }
-
-=======
     if (e.code === 'Space') {
       if (!this.bullet.isFired) {
         this.bullet.fire(
@@ -591,29 +145,6 @@ export default class Game {
     if (e.code === 'KeyP') this.togglePause();
   }
 
-=======
-  update() {
-    this.starfield.update();
-=======
-  handleKeyDown(event) {
-    if (event.key === 'ArrowLeft') {
-      this.player.moveLeft();
-    } else if (event.key === 'ArrowRight') {
-      this.player.moveRight();
-    } else if (event.key === ' ' || event.key === 'Spacebar') {
-      if (!this.bullet.isFired) {
-        const startX = this.player.x + this.player.width / 2;
-        const startY = this.player.y;
-        this.bullet.fire(startX, startY);
-      }
-    } else if (event.key === 'p' || event.key === 'P') {
-      if (!this.pausePressed) {
-        this.togglePause();
-        this.pausePressed = true;
-=======
-    }
-  }
-
   handleKeyUp(e) {
     if (e.code === 'ArrowLeft') this.player.stopLeft();
     if (e.code === 'ArrowRight') this.player.stopRight();
@@ -621,110 +152,6 @@ export default class Game {
 
   togglePause() {
     if (this.gameOver) return;
-=======
-  update() {
-    this.starfield?.update();
-    this.player.update(this.gameWidth);
-    this.bullet.update();
-
-    let edge = false;
-    this.enemies.forEach((enemy) => {
-      enemy.update(this.enemyDirection, this.enemySpeed);
-      if (enemy.x < 0 || enemy.x + enemy.width > this.gameWidth) edge = true;
-    });
-
-    if (edge) {
-      this.enemyDirection *= -1;
-      this.enemies.forEach((enemy) => enemy.moveDown(20));
-    }
-
-    this.enemies.forEach((enemy) => {
-      if (
-        this.bullet.isFired &&
-        enemy.isAlive &&
-        this.bullet.x < enemy.x + enemy.width &&
-        this.bullet.x + this.bullet.width > enemy.x &&
-        this.bullet.y < enemy.y + enemy.height &&
-        this.bullet.y + this.bullet.height > enemy.y
-      ) {
-        enemy.isAlive = false;
-        this.bullet.isFired = false;
-        this.score += 10;
-      }
-    });
-
-    updateHUD({
-      score: this.score,
-      highScore: Math.max(this.highScore, this.score),
-      lives: this.lives,
-      level: this.level,
-    });
-  }
-
-  draw() {
-    this.context.clearRect(0, 0, this.gameWidth, this.gameHeight);
-    this.starfield?.draw();
-    this.player.draw(this.context);
-    this.bullet.draw(this.context);
-    this.enemies.forEach((enemy) => enemy.draw(this.context));
-  }
-
-  // Update enemy positions and check collision with player and bullet
-  function updateEnemies() {
-    let wallHit = false;
-    let moveEnemiesDown = false;
-  spawnEnemies() {
-    for (let row = 0; row < this.enemyRows; row++) {
-      for (let col = 0; col < this.enemyCols; col++) {
-        const x =
-          col * (this.enemyWidth + this.enemyPadding) + this.enemyPadding;
-        const y =
-          row * (this.enemyHeight + this.enemyPadding) + this.enemyOffsetTop;
-        this.enemies.push(
-          new Enemy(x, y, this.enemyWidth, this.enemyHeight, '#00ffff')
-        );
-=======
-  gameLoop() {
-    this.update();
-    this.draw();
-    requestAnimationFrame(this.gameLoop);
-=======
-    } else if (event.key === 'p' || event.key === 'P') {
-      if (!this.pausePressed) {
-        this.togglePause();
-        this.pausePressed = true;
-      }
-    }
-  }
-
-  handleKeyUp(event) {
-    if (event.key === 'ArrowLeft') {
-      this.player.stopLeft();
-    } else if (event.key === 'ArrowRight') {
-      this.player.stopRight();
-    } else if (event.key === 'p' || event.key === 'P') {
-      this.pausePressed = false;
-    }
-  }
-
-        // Check collision with player
-        if (checkCollision(player, enemy)) {
-          gameOver = true;
-          screenShake(10, 300);
-          flashScreen(100);
-        }
-
-        // Check collision with bullet
-        if (bullet.isFired && checkCollision(bullet, enemy)) {
-          enemy.isAlive = false;
-          bullet.isFired = false;
-          score++;
-          playSound("explosion.wav");
-          screenShake(5, 300);
-          flashScreen(50);
-        }
-=======
-  togglePause() {
     this.isPaused = !this.isPaused;
     if (this.pauseOverlay)
       this.pauseOverlay.classList.toggle('show', this.isPaused);
@@ -735,60 +162,7 @@ export default class Game {
     if (this.starfield) {
       this.starfield.update();
       this.starfield.draw();
-=======
     }
-    if (!this.isPaused) {
-      this.gameLoop();
-  update(delta) {
-    this.starfield.update();
-=======
-=======
-    this.enemies = [];
-    for (let row = 0; row < ENEMY_ROWS; row++) {
-      for (let col = 0; col < ENEMY_COLUMNS; col++) {
-        const x =
-          ENEMY_OFFSET_LEFT + col * (ENEMY_WIDTH + ENEMY_PADDING);
-        const y =
-          ENEMY_OFFSET_TOP + row * (ENEMY_HEIGHT + ENEMY_PADDING);
-        this.enemies.push(
-          new Enemy(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, '#ffffff')
-        );
-      }
-    }
-  }
-
-  update(delta) {
-    if (this.starfield) {
-      this.starfield.update();
-      this.starfield.draw();
-=======
-    for (let row = 0; row < ENEMY_ROWS; row++) {
-      for (let col = 0; col < ENEMY_COLUMNS; col++) {
-        const x = col * (ENEMY_WIDTH + ENEMY_PADDING) + ENEMY_OFFSET_LEFT;
-        const y = row * (ENEMY_HEIGHT + ENEMY_PADDING) + ENEMY_OFFSET_TOP;
-        this.enemies.push(new Enemy(x, y, ENEMY_WIDTH, ENEMY_HEIGHT, '#00ffff'));
-      }
-    }
-  }
-
-  handleKeyDown(e) {
-    if (e.key === 'ArrowLeft' || e.key === 'a') this.player.moveLeft();
-    if (e.key === 'ArrowRight' || e.key === 'd') this.player.moveRight();
-    if (e.key === ' ' || e.code === 'Space') {
-      if (!this.bullet.isFired) {
-        this.bullet.fire(
-          this.player.x + this.player.width / 2,
-          this.player.y
-        );
-      }
-    }
-    if (e.key === 'p' || e.key === 'P') this.togglePause();
-  }
-
-  handleKeyUp(e) {
-    if (e.key === 'ArrowLeft' || e.key === 'a') this.player.stopLeft();
-    if (e.key === 'ArrowRight' || e.key === 'd') this.player.stopRight();
-  }
 
     if (this.isPaused || this.gameOver) return;
 
@@ -796,74 +170,8 @@ export default class Game {
     this.bullet.update();
 
     // move enemies
-=======
-  togglePause() {
-    if (this.gameOver) return;
-    this.isPaused = !this.isPaused;
-    if (this.isPaused) {
-      showOverlay('pauseOverlay');
-    } else {
-      hideOverlay('pauseOverlay');
-      requestAnimationFrame(() => this.gameLoop());
-    }
-
-=======
-  gameLoop() {
-    if (this.gameOver || this.isPaused) return;
-    this.update();
-    this.draw();
-    requestAnimationFrame(() => this.gameLoop());
-  }
-
-  update() {
-    if (this.starfield) this.starfield.update();
-=======
-    this.player.update(this.gameWidth);
-    this.bullet.update();
-
-    let moveDown = false;
-    for (const enemy of this.enemies) {
-      if (!enemy.isAlive) continue;
-      enemy.update(this.enemyDirection, this.enemySpeed);
-      if (enemy.x <= 0 || enemy.x + enemy.width >= this.gameWidth) {
-        moveDown = true;
-      }
-    }
-    if (moveDown) {
-      this.enemyDirection *= -1;
-      for (const enemy of this.enemies) {
-        enemy.moveDown(this.enemyHeight);
-      }
-=======
-    this.starfield.update();
-    this.player.update(this.gameWidth);
-    this.bullet.update();
-
-    // Enemy movement
-    let hitEdge = false;
-    for (const enemy of this.enemies) {
-=======
     this.enemies.forEach((enemy) => {
       enemy.update(this.enemyDirection, this.enemySpeed);
-=======
-      if (
-        enemy.x <= 0 ||
-        enemy.x + enemy.width >= this.gameWidth
-      ) {
-        hitEdge = true;
-      }
-    });
-    if (hitEdge) {
-      this.enemyDirection *= -1;
-      this.enemies.forEach((e) => e.moveDown(20));
-      enemy.update(this.enemyDirection, this.enemySpeed);
-      if (enemy.x + enemy.width > this.gameWidth || enemy.x < 0) {
-        hitEdge = true;
-      }
-    }
-    if (hitEdge) {
-      this.enemyDirection *= -1;
-=======
     });
 
     // change direction on wall hit
@@ -872,7 +180,7 @@ export default class Game {
     );
     if (hitWall) {
       this.enemyDirection *= -1;
-      this.enemies.forEach((e) => e.moveDown(ENEMY_HEIGHT / 2));
+      this.enemies.forEach((e) => e.moveDown(ENEMY.HEIGHT / 2));
     }
 
     // bullet collision
@@ -892,7 +200,10 @@ export default class Game {
     // next level if all dead
     if (this.enemies.length === 0) {
       this.level++;
-      this.enemySpeed += 0.2;
+      const levelConfig = getLevelConfig(this.level);
+      this.enemySpeed = levelConfig.enemySpeed;
+      this.player.speed = levelConfig.playerSpeed;
+      this.bullet.speed = levelConfig.bulletSpeed;
       this.spawnEnemies();
     }
 
@@ -909,306 +220,6 @@ export default class Game {
       } else {
         this.resetState();
       }
-=======
-      for (const enemy of this.enemies) {
-        enemy.moveDown(ENEMY_HEIGHT);
-      }
-      this.enemies.forEach((e) => e.moveDown(this.enemyHeight));
-=======
-      this.enemies.forEach((enemy) => enemy.moveDown(10));
-    }
-
-    for (const enemy of this.enemies) {
-      if (
-        enemy.isAlive &&
-        this.bullet.isFired &&
-        this.bullet.x < enemy.x + enemy.width &&
-        this.bullet.x + this.bullet.width > enemy.x &&
-        this.bullet.y < enemy.y + enemy.height &&
-        this.bullet.y + this.bullet.height > enemy.y
-      ) {
-        enemy.isAlive = false;
-        this.bullet.isFired = false;
-        this.score += 10;
-        if (this.score > this.highScore) {
-          this.highScore = this.score;
-          localStorage.setItem('highScore', this.highScore);
-=======
-    // Bullet collisions
-    if (this.bullet.isFired) {
-      this.enemies.forEach((enemy) => {
-        if (!enemy.isAlive) return;
-        const hit =
-=======
-      for (const enemy of this.enemies) {
-=======
-      this.enemies.forEach((enemy) => {
-        if (
-          enemy.isAlive &&
-          this.bullet.x < enemy.x + enemy.width &&
-          this.bullet.x + this.bullet.width > enemy.x &&
-          this.bullet.y < enemy.y + enemy.height &&
-          this.bullet.y + this.bullet.height > enemy.y
-=======
-=======
-    for (const enemy of this.enemies) {
-      if (!enemy.isAlive) continue;
-      enemy.update(this.enemyDirection, this.enemySpeed);
-      if (enemy.x + enemy.width > this.gameWidth || enemy.x < 0) hitEdge = true;
-
-      if (this.bullet.isFired) {
-        const bx = this.bullet.x;
-        const by = this.bullet.y;
-        const bw = this.bullet.width;
-        const bh = this.bullet.height;
-        if (
-          bx < enemy.x + enemy.width &&
-          bx + bw > enemy.x &&
-          by < enemy.y + enemy.height &&
-          by + bh > enemy.y
-        ) {
-          enemy.isAlive = false;
-          this.bullet.isFired = false;
-          this.score += 10;
-          if (this.score > this.highScore) {
-            this.highScore = this.score;
-            localStorage.setItem('highScore', this.highScore);
-          }
-          updateHUD({
-            score: this.score,
-            highScore: this.highScore,
-            lives: this.lives,
-            level: this.level,
-          });
-        }
-      });
-      });
-    }
-      }
-    }
-=======
-      }
-=======
-      });
-    }
-
-    // Check for win
-    if (allEnemiesDefeated(this.enemies)) {
-      this.endGame(true);
-    }
-
-    // Enemy reaches player
-    this.enemies.forEach((enemy) => {
-      if (!enemy.isAlive) return;
-      if (enemy.y + enemy.height >= this.player.y) {
-        this.lives -= 1;
-        enemy.isAlive = false;
-        if (this.lives <= 0) {
-          this.endGame(false);
-        }
-        updateHUD({
-          score: this.score,
-          highScore: this.highScore,
-          lives: this.lives,
-          level: this.level,
-        });
-      }
-    });
-  }
-
-  draw() {
-    this.context.clearRect(0, 0, this.gameWidth, this.gameHeight);
-    this.player.draw(this.context);
-    this.bullet.draw(this.context);
-    this.enemies.forEach((enemy) => enemy.draw(this.context));
-  }
-
-  gameLoop() {
-    if (this.starfield) {
-      this.starfield.update();
-      this.starfield.draw();
-    }
-=======
-    if (this.isPaused) {
-      requestAnimationFrame(() => this.gameLoop());
-      return;
-    }
-
-    if (this.starfield) {
-      this.starfield.update();
-      this.starfield.draw();
-    }
-
-    this.update();
-=======
-  gameLoop(timestamp) {
-    if (this.isPaused || this.gameOver || this.gameWon) return;
-    const delta = timestamp - this.lastTime;
-    this.lastTime = timestamp;
-    this.update(delta);
-    this.draw();
-    requestAnimationFrame(this.gameLoop);
-  }
-
-
-    
-    if (this.gameOver) {
-    if (!this.isPaused) {
-      this.update();
-      this.draw();
-    }
-    this.update();
-    this.draw();
-    updateHUD({
-      score: this.score,
-      highScore: this.highScore,
-      lives: this.lives,
-      level: this.level,
-    });
-      if (!this.gameOver) {
-        requestAnimationFrame(() => this.gameLoop());
-      } else {
-        if (this.enemies.every((e) => !e.isAlive)) {
-          showOverlay('winOverlay');
-        } else {
-          showOverlay('gameOverOverlay');
-        }
-        updateHUD({
-          score: this.score,
-          highScore: this.highScore,
-          lives: this.lives,
-          level: this.level,
-        });
-      }
-    }
-
-=======
-    if (!this.gameOver) {
-      requestAnimationFrame(() => this.gameLoop());
-    } else {
-=======
-      const overlayId = this.gameWon ? 'winOverlay' : 'gameOverOverlay';
-      showOverlay(overlayId);
-      saveScore('Player', this.score);
-      showLeaderboard();
-    } else {
-      requestAnimationFrame(() => this.gameLoop());
-    }
-  }
-}
-=======
-=======
-  handleKeyDown(e) {
-    switch (e.key) {
-      case 'ArrowLeft':
-      case 'a':
-        this.player.moveLeft();
-        break;
-      case 'ArrowRight':
-      case 'd':
-        this.player.moveRight();
-        break;
-      case ' ': // space
-        if (!this.bullet.isFired) {
-          this.bullet.fire(
-            this.player.x + this.player.width / 2,
-            this.player.y
-          );
-        }
-        break;
-      case 'p':
-      case 'P':
-        this.togglePause();
-        break;
-      default:
-        break;
-    }
-  }
-
-let currentGame;
-      updateLeaderboard();
-=======
-  handleKeyUp(e) {
-    switch (e.key) {
-      case 'ArrowLeft':
-      case 'a':
-        this.player.stopLeft();
-        break;
-      case 'ArrowRight':
-      case 'd':
-        this.player.stopRight();
-        break;
-      default:
-        break;
-    }
-  }
-
-  togglePause() {
-    if (this.gameOver || this.gameWon) return;
-    this.isPaused = !this.isPaused;
-    if (this.isPaused) {
-      showOverlay('pauseOverlay');
-    } else {
-      hideOverlay('pauseOverlay');
-      requestAnimationFrame(this.gameLoop);
-    }
-  }
-
-  endGame(won) {
-    this.gameOver = !won;
-    this.gameWon = won;
-    this.isPaused = true;
-    const name = prompt('Enter your name:', 'Player');
-    if (name) saveScore(name, this.score);
-    if (won) {
-      showOverlay('winOverlay');
-    } else {
-      showOverlay('gameOverOverlay');
-=======
-      }
-
-      if (enemy.y + enemy.height >= this.player.y) {
-        this.lives -= 1;
-        if (this.lives <= 0) {
-          this.endGame();
-        } else {
-          this.resetState();
-        }
-        return;
-      }
-    }
-
-    if (hitEdge) {
-      this.enemyDirection *= -1;
-      for (const enemy of this.enemies) {
-        enemy.moveDown(10);
-      }
-    }
-
-    if (this.bullet.isFired) {
-      this.enemies.forEach((enemy) => {
-        if (enemy.isAlive && this.checkCollision(this.bullet, enemy)) {
-          enemy.isAlive = false;
-          this.bullet.isFired = false;
-          this.score += 10;
-          if (this.score > this.highScore) {
-            this.highScore = this.score;
-          }
-          this.updateHUD();
-        }
-    if (reachedBottom) {
-      this.lives--;
-=======
-    if (this.enemies.every((e) => !e.isAlive)) {
-      this.level += 1;
-      this.enemySpeed += 0.2;
-      this.spawnEnemies();
-      updateHUD({
-        score: this.score,
-        highScore: this.highScore,
-        lives: this.lives,
-        level: this.level,
-      });
     }
 
     updateHUD({
@@ -1220,25 +231,13 @@ let currentGame;
   }
 
   draw() {
-    this.starfield.draw();
     this.ctx.clearRect(0, 0, this.gameWidth, this.gameHeight);
     this.player.draw(this.ctx);
     this.bullet.draw(this.ctx);
-    for (const enemy of this.enemies) enemy.draw(this.ctx);
-=======
-=======
-    for (const enemy of this.enemies) {
-      enemy.draw(this.ctx);
-    }
-
-    // Request next animation frame
-    requestAnimationFrame(gameLoop);
-
     this.enemies.forEach((e) => e.draw(this.ctx));
   }
 
   gameLoop() {
-    if (this.gameOver) return;
     this.update();
     this.draw();
     if (!this.isPaused && !this.gameOver) {
@@ -1246,9 +245,6 @@ let currentGame;
     }
   }
 
-const game = new Game();
-document.addEventListener('DOMContentLoaded', () => initGameUI(game));
-=======
   checkCollision(a, b) {
     return (
       a.x < b.x + b.width &&
@@ -1262,20 +258,6 @@ document.addEventListener('DOMContentLoaded', () => initGameUI(game));
     this.gameOver = true;
     this.highScore = Math.max(this.highScore, this.score);
     localStorage.setItem('highScore', this.highScore);
-=======
-    requestAnimationFrame(this.gameLoop);
-=======
-  }
-
-export { updateHUD, saveScore, showLeaderboard, hideLeaderboard };
-=======
-=======
-  endGame() {
-    this.gameOver = true;
-    if (this.score > this.highScore) {
-      this.highScore = this.score;
-      localStorage.setItem('highScore', this.highScore);
-    }
     updateHUD({
       score: this.score,
       highScore: this.highScore,
@@ -1287,10 +269,4 @@ export { updateHUD, saveScore, showLeaderboard, hideLeaderboard };
     showLeaderboard();
   }
 }
-=======
-  }
-}
-export { showLeaderboard, hideLeaderboard };
-=======
 
-  


### PR DESCRIPTION
## Summary
- add `config.js` with shared player, bullet, and enemy constants
- refactor game logic to consume config and scale speed by level

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check game.js`
- `node --check config.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4c127a0888328adfa50992b13566b