### PR TITLE
Keep leaderboard listeners in `initGameUI`; remove duplicate bindings from `initHUD`

### DIFF
--- a/hud.js
+++ b/hud.js
@@ -15,13 +15,6 @@ function initHUD() {
   leaderboardOverlay = document.getElementById('leaderboardOverlay');
   leaderboardList = document.getElementById('leaderboardList');
 
-  const leaderboardButton = document.getElementById('leaderboardButton');
-  const closeLeaderboard = document.getElementById('closeLeaderboard');
-  if (leaderboardButton)
-    leaderboardButton.addEventListener('click', showLeaderboard);
-  if (closeLeaderboard)
-    closeLeaderboard.addEventListener('click', hideLeaderboard);
-
   updateLeaderboard();
 }
 


### PR DESCRIPTION
### Motivation
- Prevent duplicate click handlers for the leaderboard that caused `showLeaderboard`/`hideLeaderboard` to be registered more than once by choosing a single ownership point. 
- Centralize UI event wiring in the game UI initializer so HUD initialization focuses on element caching and leaderboard data refresh.

### Description
- Chose `ui.js:initGameUI` as the single ownership point for leaderboard button listeners and left the `showLeaderboard`/`hideLeaderboard` bindings there. 
- Removed duplicate `leaderboardButton` and `closeLeaderboard` `click` listener registration from `hud.js:initHUD`. 
- Kept `hud.js` responsibilities to cache DOM references and call `updateLeaderboard()` without attaching UI event listeners.

### Testing
- Searched the repo for remaining bindings with `rg -n "addEventListener\('click', showLeaderboard\)|addEventListener\('click', hideLeaderboard\)"` and confirmed only `ui.js` contains the leaderboard `click` listeners (no duplicates). — succeeded. 
- Ran syntax checks with `node --check hud.js && node --check ui.js` to ensure modified modules parse correctly — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6cdc12c8328aadb7802cf9b6fe9)