### PR TITLE
Add robust payload validation for POST /scores

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,12 +20,55 @@ db.serialize(() => {
   );
 });
 
+const NAME_MIN_LENGTH = 1;
+const NAME_MAX_LENGTH = 20;
+const SCORE_MIN = 0;
+const SCORE_MAX = 1_000_000;
+
+function validateScorePayload(payload) {
+  const fieldErrors = {};
+  const result = {};
+  const { name, score } = payload ?? {};
+
+  if (typeof name !== 'string') {
+    fieldErrors.name = 'Name must be a string.';
+  } else {
+    const normalizedName = name.replace(/[\x00-\x1F\x7F]/g, '').trim();
+    if (normalizedName.length < NAME_MIN_LENGTH || normalizedName.length > NAME_MAX_LENGTH) {
+      fieldErrors.name = `Name length must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters.`;
+    } else {
+      result.name = normalizedName;
+    }
+  }
+
+  if (!Number.isInteger(score)) {
+    fieldErrors.score = 'Score must be an integer.';
+  } else if (score < SCORE_MIN || score > SCORE_MAX) {
+    fieldErrors.score = `Score must be between ${SCORE_MIN} and ${SCORE_MAX}.`;
+  } else {
+    result.score = score;
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      ok: false,
+      error: {
+        message: 'Validation failed',
+        fields: fieldErrors
+      }
+    };
+  }
+
+  return { ok: true, value: result };
+}
+
 // Route to submit a score
 app.post('/scores', (req, res) => {
-  const { name, score } = req.body;
-  if (typeof name !== 'string' || typeof score !== 'number') {
-    return res.status(400).json({ error: 'Invalid payload' });
+  const validation = validateScorePayload(req.body);
+  if (!validation.ok) {
+    return res.status(400).json(validation.error);
   }
+  const { name, score } = validation.value;
 
   const stmt = db.prepare('INSERT INTO scores (name, score) VALUES (?, ?)');
   stmt.run(name, score, function (err) {


### PR DESCRIPTION
### Motivation
- Prevent malformed or unsafe leaderboard entries by validating and normalizing incoming `POST /scores` payloads and returning clear field-level errors instead of a generic 400.

### Description
- Add constants `NAME_MIN_LENGTH`, `NAME_MAX_LENGTH`, `SCORE_MIN`, and `SCORE_MAX` to centralize validation ranges.
- Add a `validateScorePayload(payload)` helper that strips ASCII control characters from `name`, trims whitespace, enforces a `1–20` character limit, requires `score` to be an integer, and enforces the `0..1,000,000` range, returning `{ ok: true, value }` or `{ ok: false, error }`.
- Update the `POST /scores` route to call `validateScorePayload`, return structured HTTP 400 responses with a top-level `message` and `fields` for per-field errors, and insert only validated/normalized values into SQLite.
- Keep the route handler concise by moving validation logic into the helper.

### Testing
- Ran `node --check server.js` and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6cf0e208328b988f3e5e67ee0d3)