### PR TITLE
Add MAX_LEVEL win rule and terminal gameWon state with consistent score handling

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,6 +22,8 @@ export const ENEMY = {
   SPEED_INCREMENT: 0.2,
 };
 
+export const MAX_LEVEL = 3;
+
 export function getLevelConfig(level) {
   return {
     playerSpeed: PLAYER.SPEED,

--- a/game.js
+++ b/game.js
@@ -8,7 +8,13 @@ import {
   showLeaderboard,
   hideLeaderboard,
 } from './hud.js';
-import { PLAYER, BULLET, ENEMY, getLevelConfig } from './config.js';
+import {
+  PLAYER,
+  BULLET,
+  ENEMY,
+  MAX_LEVEL,
+  getLevelConfig,
+} from './config.js';
 
 function showOverlay(id) {
   const el = document.getElementById(id);
@@ -19,6 +25,8 @@ function hideOverlay(id) {
   const el = document.getElementById(id);
   if (el) el.classList.remove('show');
 }
+
+export { hideOverlay };
 
 export default class Game {
   constructor() {
@@ -61,10 +69,12 @@ export default class Game {
       this.lives = 3;
       this.isPaused = false;
       this.gameOver = false;
+      this.gameWon = false;
 
     // overlays
     this.startOverlay = document.getElementById('startOverlay');
     this.gameOverOverlay = document.getElementById('gameOverOverlay');
+    this.winOverlay = document.getElementById('winOverlay');
     this.pauseOverlay = document.getElementById('pauseOverlay');
 
     // bind methods
@@ -99,10 +109,12 @@ export default class Game {
   start() {
     hideOverlay('startOverlay');
     hideOverlay('gameOverOverlay');
+    hideOverlay('winOverlay');
     hideOverlay('pauseOverlay');
     hideLeaderboard();
 
     this.gameOver = false;
+    this.gameWon = false;
     this.isPaused = false;
     this.score = 0;
     this.lives = 3;
@@ -114,6 +126,8 @@ export default class Game {
   }
 
   reset() {
+    this.gameOver = false;
+    this.gameWon = false;
     this.start();
   }
 
@@ -151,7 +165,7 @@ export default class Game {
   }
 
   togglePause() {
-    if (this.gameOver) return;
+    if (this.gameOver || this.gameWon) return;
     this.isPaused = !this.isPaused;
     if (this.pauseOverlay)
       this.pauseOverlay.classList.toggle('show', this.isPaused);
@@ -164,7 +178,7 @@ export default class Game {
       this.starfield.draw();
     }
 
-    if (this.isPaused || this.gameOver) return;
+    if (this.isPaused || this.gameOver || this.gameWon) return;
 
     this.player.update(this.gameWidth);
     this.bullet.update();
@@ -199,6 +213,10 @@ export default class Game {
 
     // next level if all dead
     if (this.enemies.length === 0) {
+      if (this.level >= MAX_LEVEL) {
+        this.endWin();
+        return;
+      }
       this.level++;
       const levelConfig = getLevelConfig(this.level);
       this.enemySpeed = levelConfig.enemySpeed;
@@ -240,7 +258,7 @@ export default class Game {
   gameLoop() {
     this.update();
     this.draw();
-    if (!this.isPaused && !this.gameOver) {
+    if (!this.isPaused && !this.gameOver && !this.gameWon) {
       requestAnimationFrame(this.gameLoop);
     }
   }
@@ -254,8 +272,7 @@ export default class Game {
     );
   }
 
-  endGame() {
-    this.gameOver = true;
+  finalizeScore() {
     this.highScore = Math.max(this.highScore, this.score);
     localStorage.setItem('highScore', this.highScore);
     updateHUD({
@@ -264,9 +281,19 @@ export default class Game {
       lives: this.lives,
       level: this.level,
     });
-    showOverlay('gameOverOverlay');
     saveScore('Player', this.score);
     showLeaderboard();
   }
-}
 
+  endGame() {
+    this.gameOver = true;
+    this.finalizeScore();
+    showOverlay('gameOverOverlay');
+  }
+
+  endWin() {
+    this.gameWon = true;
+    this.finalizeScore();
+    showOverlay('winOverlay');
+  }
+}

--- a/ui.js
+++ b/ui.js
@@ -25,11 +25,13 @@ function initGameUI(game) {
     restartButton.addEventListener('click', () => {
       game.reset();
       hideOverlay('gameOverOverlay');
+      hideOverlay('winOverlay');
     });
   }
   if (playAgainButton) {
     playAgainButton.addEventListener('click', () => {
       game.reset();
+      hideOverlay('gameOverOverlay');
       hideOverlay('winOverlay');
     });
   }


### PR DESCRIPTION
### Motivation
- Introduce an explicit win rule so the game can end in victory when the player clears the final level.
- Ensure win and lose flows behave consistently: both should stop the main loop, persist high score, update HUD, save leaderboard entries, and present overlays.
- Make sure restart/play-again UI resets any terminal state so games can be replayed cleanly.

### Description
- Added `MAX_LEVEL` to `config.js` to define the final level that triggers a win. (`config.js`)
- Implemented a terminal `gameWon` boolean in `Game` and stop the game loop/update when `gameWon` is true, mirroring `gameOver` behavior. (`game.js`)
- When the player clears the final level (`level >= MAX_LEVEL`) call `endWin()` which sets `gameWon`, shows `winOverlay`, and reuses `finalizeScore()` to persist/update HUD, store `highScore`, save the score, and show the leaderboard. (`game.js`)
- Centralized end-of-run logic into `finalizeScore()` to ensure identical score/high-score persistence and leaderboard save for both win and lose paths. (`game.js`)
- Prevent toggling pause when in terminal win/lose states and stop requestAnimationFrame when won. (`game.js`)
- Exported `hideOverlay` from `game.js` and updated `ui.js` so `restart` and `play again` handlers hide both `gameOverOverlay` and `winOverlay` and reset `gameOver`/`gameWon`. (`game.js`, `ui.js`)

### Testing
- Ran static syntax checks: `node --check game.js`, `node --check ui.js`, and `node --check config.js`, all succeeded.
- No automated unit tests exist in the project; manual behavior verified through the code paths for level advancement, `endWin()` and `endGame()` logic during the rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6d052b083288df2757ed1582040)