### PR TITLE
Use db.run for one-shot inserts and add graceful SIGINT/SIGTERM shutdown with logging

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,8 +27,7 @@ app.post('/scores', (req, res) => {
     return res.status(400).json({ error: 'Invalid payload' });
   }
 
-  const stmt = db.prepare('INSERT INTO scores (name, score) VALUES (?, ?)');
-  stmt.run(name, score, function (err) {
+  db.run('INSERT INTO scores (name, score) VALUES (?, ?)', [name, score], function (err) {
     if (err) {
       console.error('DB insert error', err);
       return res.status(500).json({ error: 'Failed to save score' });
@@ -54,12 +53,39 @@ app.use((err, req, res, next) => {
   res.status(500).json({ error: 'Internal server error' });
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
 
 // Graceful shutdown
-process.on('SIGINT', () => {
-  db.close();
-  process.exit();
-});
+let isShuttingDown = false;
+function shutdown(signal) {
+  if (isShuttingDown) {
+    console.log(`Shutdown already in progress (received ${signal}).`);
+    return;
+  }
+  isShuttingDown = true;
+  console.log(`Received ${signal}. Starting graceful shutdown...`);
+
+  server.close((serverErr) => {
+    if (serverErr) {
+      console.error('HTTP server close error during shutdown', serverErr);
+    } else {
+      console.log('HTTP server closed.');
+    }
+
+    db.close((dbErr) => {
+      if (dbErr) {
+        console.error('Database close error during shutdown', dbErr);
+        process.exit(1);
+        return;
+      }
+      console.log('Database connection closed.');
+      console.log('Graceful shutdown complete. Exiting process.');
+      process.exit(serverErr ? 1 : 0);
+    });
+  });
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
### Motivation
- Prevent prepared-statement leaks by using a one-shot `db.run(...)` for single inserts or ensuring statements are explicitly finalized in all paths.
- Make shutdown deterministic and diagnosable in production by closing the HTTP server and DB before exiting and by handling both `SIGINT` and `SIGTERM`.
- Improve observability during shutdown so operational issues can be diagnosed via logs.

### Description
- Replaced the prepared-statement usage in `POST /scores` with a direct `db.run('INSERT INTO scores ...', [name, score], ...)` call to avoid leaving un-finalized statements.
- Kept the response behavior intact by returning the inserted `id` via `this.lastID` in the `db.run` callback.
- Captured the HTTP server handle as `server = app.listen(...)` and added an idempotent `shutdown(signal)` routine that logs signal receipt and progress.
- On shutdown, the code now calls `server.close(...)` before `db.close(...)`, logs outcomes for both operations, and exits with a non-zero code when close errors occur, with handlers wired for both `SIGINT` and `SIGTERM`.

### Testing
- Ran a Node syntax check with `node --check server.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede6d1108083288b2b9d99c4d5bcda)